### PR TITLE
Fix loading of article and clearing of state in editor page

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -36,8 +36,8 @@ export default class App extends React.Component {
           <Switch>
             <Route path="/login" component={Login} />
             <Route path="/register" component={Register} />
-            <Route path="/editor" component={Editor} />
             <Route path="/editor/:slug" component={Editor} />
+            <Route path="/editor" component={Editor} />
             <Route path="/article/:id" component={Article} />
             <Route path="/settings" component={Settings} />
             <Route path="/@:username" component={Profile} />

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -36,8 +36,7 @@ export default class App extends React.Component {
           <Switch>
             <Route path="/login" component={Login} />
             <Route path="/register" component={Register} />
-            <Route path="/editor/:slug" component={Editor} />
-            <Route path="/editor" component={Editor} />
+            <Route path="/editor/:slug?" component={Editor} />
             <Route path="/article/:id" component={Article} />
             <Route path="/settings" component={Settings} />
             <Route path="/@:username" component={Profile} />

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -18,8 +18,8 @@ export default class Editor extends React.Component {
     this.props.editorStore.loadInitialData();
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.match.params.slug !== nextProps.match.params.slug) {
+  componentDidUpdate(prevProps) {
+    if (this.props.match.params.slug !== prevProps.match.params.slug) {
       this.props.editorStore.setArticleSlug(this.props.match.params.slug);
       this.props.editorStore.loadInitialData();
     }

--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -19,7 +19,7 @@ export default class Editor extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (this.props.match.params.slug !== nextProps.params.slug) {
+    if (this.props.match.params.slug !== nextProps.match.params.slug) {
       this.props.editorStore.setArticleSlug(this.props.match.params.slug);
       this.props.editorStore.loadInitialData();
     }

--- a/src/stores/editorStore.js
+++ b/src/stores/editorStore.js
@@ -14,7 +14,7 @@ class EditorStore {
 
   @action setArticleSlug(articleSlug) {
     if (this.articleSlug !== articleSlug) {
-      this.comments = [];
+      this.reset();
       this.articleSlug = articleSlug;
     }
   }


### PR DESCRIPTION
References #15 

This change updates to the router to use a single Editor route entry with an optional parameter (`/editor/:slug?`). It also corrects a typo in the nextProps.match.params access. These two changes restored the 'article editing' functionality for my locally running instance. 

Please let me know if there's anything that needs changing. 