### PR TITLE
Remove redundant props passed to Header

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -33,10 +33,7 @@ export default class App extends React.Component {
     if (this.props.commonStore.appLoaded) {
       return (
         <div>
-          <Header
-            appName={this.props.appName}
-            currentUser={this.props.currentUser}
-          />
+          <Header />
           <Switch>
             <Route path="/login" component={Login} />
             <Route path="/register" component={Register} />


### PR DESCRIPTION
The AppName and CurrentUser props passed to Header  are unnecessary，since the Header fetch these data directly from the store.